### PR TITLE
Update SeriesDetails.vue

### DIFF
--- a/src/views/SeriesDetails.vue
+++ b/src/views/SeriesDetails.vue
@@ -23,7 +23,7 @@
 							<tag>Status: {{ seriesData.status.toLowerCase() }}</tag>
 							<!-- Genres -->
 							<tag
-								v-for="genre in seriesData.genre.split(', ')"
+								v-for="genre in seriesData.genre"
 								:key="`genre-${genre.toLowerCase()}`"
 							>
 								{{ genre }}


### PR DESCRIPTION
https://github.com/Suwayomi/Tachidesk-Server/pull/188

remove split for genre because the new changes in api
it uses ```List<string>``` instead of string spaced with comma