### PR TITLE
Basic potrait mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,8 +21,7 @@
 		height: auto;
 	}
 	.main-layout {
-		grid-template-columns: none;
-		grid-template-rows: auto;
+		display: block;
 	}
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,10 +16,13 @@
 
 @media (orientation: portrait) {
 	.sidebar {
-		display: none;
+		position: relative;
+		width: auto;
+		height: auto;
 	}
 	.main-layout {
-		grid-template-columns: 100%;
+		grid-template-columns: none;
+		grid-template-rows: auto;
 	}
 }
 </style>

--- a/src/views/SeriesDetails.vue
+++ b/src/views/SeriesDetails.vue
@@ -107,6 +107,18 @@ section + section {
 	flex-wrap: wrap;
 	gap: 5px;
 }
+@media (orientation: portrait) {
+	.details-layout {
+		grid-template-columns: none;
+		grid-template-rows: auto 1fr;
+	}
+	.is-poster {
+		margin-top: -10rem;
+		margin-left: auto;
+		margin-right: auto;
+		width: 13rem;
+	}
+}
 </style>
 
 <script lang="ts">

--- a/src/views/SeriesDetails.vue
+++ b/src/views/SeriesDetails.vue
@@ -109,8 +109,7 @@ section + section {
 }
 @media (orientation: portrait) {
 	.details-layout {
-		grid-template-columns: none;
-		grid-template-rows: auto 1fr;
+		display: block;
 	}
 	.is-poster {
 		margin-top: -10rem;


### PR DESCRIPTION
change `grid-template-colums` to `grid-template-rows`
center poster thumbnail and use `rem` for responsive on different screens

![image](https://user-images.githubusercontent.com/30526233/134474993-4c99b52f-497d-4ffc-8768-71a65c74776d.png)
